### PR TITLE
Implement Default, Add and AddAssign traits for WordsCount

### DIFF
--- a/.github/workflows/ci-version.yml
+++ b/.github/workflows/ci-version.yml
@@ -1,6 +1,7 @@
 name: CI-version
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [ push, pull_request ]
+on: [ workflow_dispatch, push, pull_request ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,16 +28,59 @@ assert_eq!(Some(&2), result.get("apple"));
 
 extern crate alloc;
 
+use core::ops::{Add, AddAssign};
 use core::str::from_utf8_unchecked;
 
 use alloc::collections::BTreeMap;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct WordsCount {
     pub words: usize,
     pub characters: usize,
     pub whitespaces: usize,
     pub cjk: usize,
+}
+
+/// A WordsCount equivalent to words_count::count("\n").
+///
+/// It is useful when processing files a line at a time.
+///
+/// ## Example
+///
+/// ```rust
+/// use words_count::{count, WordsCount, NEWLINE};
+///
+/// let mut total = WordsCount::default();
+/// for ln in std::io::stdin().lines() {
+///     total += count(ln.unwrap()) + NEWLINE;
+/// }
+/// println!("{total:?}");
+/// ```
+pub const NEWLINE: WordsCount = WordsCount {
+    words: 0,
+    characters: 1,
+    whitespaces: 1,
+    cjk: 0,
+};
+
+impl AddAssign for WordsCount {
+    fn add_assign(&mut self, other: Self) {
+        *self = Self {
+            words: self.words + other.words,
+            characters: self.characters + other.characters,
+            whitespaces: self.whitespaces + other.whitespaces,
+            cjk: self.cjk + other.cjk,
+        }
+    }
+}
+
+impl Add for WordsCount {
+    type Output = Self;
+
+    fn add(mut self, other: Self) -> Self {
+        self += other;
+        self
+    }
 }
 
 /// Count the words in the given string. In general, every non-CJK string of characters between two whitespaces is a word. Dashes (at least two dashes) are word limit, too. A CJK character is considered to be an independent word.


### PR DESCRIPTION
The new traits, combined with the NEWLINE constant, allow us to process files a line at a time. For example:

```rust
use std::io;
use words_count::WordsCount;

fn wc() -> io::Result<WordsCount> {
    let mut total = WordsCount::default();

    for ln in io::stdin().lines() {
        total += words_count::count(ln?) + words_count::NEWLINE;
    }

    Ok(total)
}
```
NEWLINE is documented with an example similar to the above.