### PR TITLE
fix: don't consider CJK punctuation as words

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ assert_eq!(WordsCount {
     words: 18,
     characters: 31,
     whitespaces: 2,
-    cjk: 16,
+    cjk: 18,
 }, words_count::count("Rust是由 Mozilla 主導開發的通用、編譯型程式語言。"));
 ```
 
@@ -132,6 +132,8 @@ pub fn count<S: AsRef<str>>(s: S) -> WordsCount {
                     consecutive_dashes = 0;
 
                     if is_cjk_other(c) {
+                        count.cjk += 1;
+
                         continue;
                     } else if unicode_blocks::is_cjk(c) {
                         count.words += 1;

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -44,7 +44,7 @@ fn english_alphabet() {
 fn cjk_alphabet() {
     assert_eq!(
         WordsCount {
-            words: 21, characters: 24, whitespaces: 1, cjk: 21
+            words: 21, characters: 24, whitespaces: 1, cjk: 23
         },
         count("涼風有訊 秋月無邊。虧我思嬌的情緒好比度日如年。")
     );
@@ -54,7 +54,7 @@ fn cjk_alphabet() {
 fn english_cjk_mix() {
     assert_eq!(
         WordsCount {
-            words: 12, characters: 28, whitespaces: 0, cjk: 10
+            words: 12, characters: 28, whitespaces: 0, cjk: 12
         },
         count("大家來meething吧，不然要錯過deadline了。")
     );

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -44,7 +44,7 @@ fn english_alphabet() {
 fn cjk_alphabet() {
     assert_eq!(
         WordsCount {
-            words: 23, characters: 24, whitespaces: 1, cjk: 23
+            words: 21, characters: 24, whitespaces: 1, cjk: 21
         },
         count("涼風有訊 秋月無邊。虧我思嬌的情緒好比度日如年。")
     );
@@ -54,7 +54,7 @@ fn cjk_alphabet() {
 fn english_cjk_mix() {
     assert_eq!(
         WordsCount {
-            words: 14, characters: 28, whitespaces: 0, cjk: 12
+            words: 12, characters: 28, whitespaces: 0, cjk: 10
         },
         count("大家來meething吧，不然要錯過deadline了。")
     );


### PR DESCRIPTION
I noticed some issues with the CJK and word counter overall where punctuation was being miscounted. It looks like two 3 tests had incorrect assertions that falsly claimed what the count of `words` was supposed to be because of characters that were CJK but not "word" characters (punctuation or other non-word). This PR adds a check to see if the character is a CJK "other" and `continue`s to the next iteration - not incrementing the word counter *and* not resetting `in_word` to `true`. Also obviously updates the tests to assert the correct count of `words`.